### PR TITLE
fix: P0 reliability bugfixes — dup session.started, empty-response retry cap, replay metrics

### DIFF
--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -396,14 +396,8 @@ class OrchestratorRunner:
 
         tracker = session_result.value
 
-        # Emit session started event
-        start_event = create_session_started_event(
-            session_id=tracker.session_id,
-            execution_id=exec_id,
-            seed_id=seed.metadata.seed_id,
-            seed_goal=seed.goal,
-        )
-        await self._event_store.append(start_event)
+        # NOTE: SessionRepository.create_session() already emits
+        # orchestrator.session.started — do NOT emit a second one here.
 
         # Build prompts with strategy
         strategy = get_strategy(seed.task_type)

--- a/src/ouroboros/orchestrator/session.py
+++ b/src/ouroboros/orchestrator/session.py
@@ -22,6 +22,7 @@ Usage:
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -209,15 +210,40 @@ class SessionRepository:
     ) -> Result[SessionTracker, PersistenceError]:
         """Create a new session and persist start event.
 
+        Idempotent: if a session with the given session_id already exists,
+        returns the existing tracker instead of creating a duplicate.
+
         Args:
             execution_id: Workflow execution ID.
             seed_id: Seed ID being executed.
             session_id: Optional custom session ID.
 
         Returns:
-            Result containing new SessionTracker.
+            Result containing new or existing SessionTracker.
         """
         tracker = SessionTracker.create(execution_id, seed_id, session_id)
+
+        # Idempotency guard: check for existing session.started event
+        if session_id is not None:
+            try:
+                existing_events = await self._event_store.replay(
+                    "session", session_id
+                )
+                has_start = any(
+                    e.type == "orchestrator.session.started"
+                    for e in existing_events
+                )
+                if has_start:
+                    log.info(
+                        "orchestrator.session.create_idempotent",
+                        session_id=session_id,
+                        execution_id=execution_id,
+                    )
+                    result = await self.reconstruct_session(session_id)
+                    if result.is_ok:
+                        return result
+            except Exception:
+                pass  # Fall through to create
 
         event = BaseEvent(
             type="orchestrator.session.started",
@@ -398,6 +424,7 @@ class SessionRepository:
         Returns:
             Result containing reconstructed SessionTracker.
         """
+        t0 = time.monotonic()
         try:
             events = await self._event_store.replay("session", session_id)
 
@@ -456,20 +483,26 @@ class SessionRepository:
                 messages_processed=messages_processed,
             )
 
+            duration_ms = (time.monotonic() - t0) * 1000
             log.info(
                 "orchestrator.session.reconstructed",
                 session_id=session_id,
                 status=tracker.status.value,
                 messages_processed=messages_processed,
+                event_count_replayed=len(events),
+                duration_ms=round(duration_ms, 2),
+                path="replay",
             )
 
             return Result.ok(tracker)
 
         except Exception as e:
+            duration_ms = (time.monotonic() - t0) * 1000
             log.exception(
                 "orchestrator.session.reconstruct_failed",
                 session_id=session_id,
                 error=str(e),
+                duration_ms=round(duration_ms, 2),
             )
             return Result.err(
                 PersistenceError(

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -48,6 +48,7 @@ log = structlog.get_logger(__name__)
 # Retry configuration for transient API errors
 _MAX_RETRIES = 5
 _INITIAL_BACKOFF_SECONDS = 2.0  # Increased for custom CLI startup
+_MAX_EMPTY_RESPONSE_WITH_SESSION = 2  # Terminal after this many consecutive empty responses with session_id
 _RETRYABLE_ERROR_PATTERNS = (
     "concurrency",
     "rate",
@@ -231,6 +232,7 @@ class ClaudeCodeAdapter:
         )
 
         last_error: ProviderError | None = None
+        consecutive_empty_with_session = 0
 
         for attempt in range(_MAX_RETRIES):
             try:
@@ -244,8 +246,35 @@ class ClaudeCodeAdapter:
                         )
                     return result
 
-                # Check if error is retryable
+                # Track consecutive empty responses with session_id
                 error_msg = result.error.message
+                error_details = result.error.details or {}
+                has_session_id = error_details.get("session_id") is not None
+
+                if "empty response" in error_msg.lower() and has_session_id:
+                    consecutive_empty_with_session += 1
+                    if consecutive_empty_with_session >= _MAX_EMPTY_RESPONSE_WITH_SESSION:
+                        log.error(
+                            "claude_code_adapter.empty_response_terminal",
+                            session_id=error_details.get("session_id"),
+                            attempt_count=consecutive_empty_with_session,
+                            prompt_preview=prompt[:100],
+                        )
+                        return Result.err(
+                            ProviderError(
+                                message="Terminal empty response - session started but content generation failed",
+                                details={
+                                    "fault_code": "CLAUDE_EMPTY_RESPONSE",
+                                    "session_id": error_details.get("session_id"),
+                                    "attempt_count": consecutive_empty_with_session,
+                                    "prompt_preview": prompt[:100],
+                                },
+                            )
+                        )
+                else:
+                    consecutive_empty_with_session = 0
+
+                # Check if error is retryable
                 if self._is_retryable_error(error_msg) and attempt < _MAX_RETRIES - 1:
                     backoff = _INITIAL_BACKOFF_SECONDS * (2**attempt)
                     log.warning(

--- a/tests/unit/orchestrator/test_session.py
+++ b/tests/unit/orchestrator/test_session.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -332,3 +332,124 @@ class TestSessionRepository:
 
         assert result.is_ok
         assert result.value.status == SessionStatus.FAILED
+
+
+class TestSessionReplayMetrics:
+    """Tests for P0-AC0: baseline replay-cost metrics."""
+
+    @pytest.fixture
+    def mock_event_store(self) -> AsyncMock:
+        store = AsyncMock()
+        store.append = AsyncMock()
+        store.replay = AsyncMock(return_value=[])
+        return store
+
+    @pytest.fixture
+    def repository(self, mock_event_store: AsyncMock) -> SessionRepository:
+        return SessionRepository(mock_event_store)
+
+    @pytest.mark.asyncio
+    async def test_reconstruct_logs_replay_metrics(
+        self,
+        repository: SessionRepository,
+        mock_event_store: AsyncMock,
+    ) -> None:
+        """Verify reconstruct_session emits event_count_replayed and duration_ms."""
+        start_event = MagicMock()
+        start_event.type = "orchestrator.session.started"
+        start_event.data = {
+            "execution_id": "exec",
+            "seed_id": "seed",
+            "start_time": datetime.now(UTC).isoformat(),
+        }
+        progress_events = []
+        for i in range(10):
+            ev = MagicMock()
+            ev.type = "orchestrator.progress.updated"
+            ev.data = {"progress": {"step": i}}
+            progress_events.append(ev)
+
+        mock_event_store.replay.return_value = [start_event, *progress_events]
+
+        with patch("ouroboros.orchestrator.session.log") as mock_log:
+            result = await repository.reconstruct_session("sess_metrics")
+
+        assert result.is_ok
+        assert result.value.messages_processed == 10
+
+        # Verify the info log was called with metrics kwargs
+        mock_log.info.assert_called()
+        call_kwargs = mock_log.info.call_args
+        assert call_kwargs.kwargs["event_count_replayed"] == 11
+        assert "duration_ms" in call_kwargs.kwargs
+        assert call_kwargs.kwargs["path"] == "replay"
+
+
+class TestSessionIdempotencyGuard:
+    """Tests for P0-AC2: duplicate session.started fix + idempotency guard."""
+
+    @pytest.fixture
+    def mock_event_store(self) -> AsyncMock:
+        store = AsyncMock()
+        store.append = AsyncMock()
+        store.replay = AsyncMock(return_value=[])
+        return store
+
+    @pytest.fixture
+    def repository(self, mock_event_store: AsyncMock) -> SessionRepository:
+        return SessionRepository(mock_event_store)
+
+    @pytest.mark.asyncio
+    async def test_create_session_twice_same_id_single_event(
+        self,
+        repository: SessionRepository,
+        mock_event_store: AsyncMock,
+    ) -> None:
+        """Call create_session() twice with same session_id, verify single event."""
+        # First call: no existing events -> creates normally
+        mock_event_store.replay.return_value = []
+        result1 = await repository.create_session(
+            execution_id="exec_1",
+            seed_id="seed_1",
+            session_id="dedup_session",
+        )
+        assert result1.is_ok
+        assert mock_event_store.append.call_count == 1
+
+        # Second call: existing start event found -> returns existing tracker
+        start_event = MagicMock()
+        start_event.type = "orchestrator.session.started"
+        start_event.data = {
+            "execution_id": "exec_1",
+            "seed_id": "seed_1",
+            "start_time": datetime.now(UTC).isoformat(),
+        }
+        mock_event_store.replay.return_value = [start_event]
+
+        result2 = await repository.create_session(
+            execution_id="exec_1",
+            seed_id="seed_1",
+            session_id="dedup_session",
+        )
+        assert result2.is_ok
+        # append should NOT have been called again
+        assert mock_event_store.append.call_count == 1
+        assert result2.value.session_id == "dedup_session"
+
+    @pytest.mark.asyncio
+    async def test_create_session_auto_id_no_dedup_check(
+        self,
+        repository: SessionRepository,
+        mock_event_store: AsyncMock,
+    ) -> None:
+        """Auto-generated session IDs skip the idempotency check (no collision risk)."""
+        mock_event_store.replay.return_value = []
+        result = await repository.create_session(
+            execution_id="exec_1",
+            seed_id="seed_1",
+        )
+        assert result.is_ok
+        # replay should NOT be called for idempotency when session_id is auto-generated
+        # (replay is only called if session_id is explicitly provided)
+        mock_event_store.replay.assert_not_called()
+        mock_event_store.append.assert_called_once()

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -1,0 +1,184 @@
+"""Unit tests for ClaudeCodeAdapter empty-response retry cap (P0-AC1)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ouroboros.core.types import Result
+from ouroboros.providers.base import CompletionConfig, Message, MessageRole
+from ouroboros.providers.claude_code_adapter import (
+    ClaudeCodeAdapter,
+    _MAX_EMPTY_RESPONSE_WITH_SESSION,
+)
+
+
+@pytest.fixture
+def adapter() -> ClaudeCodeAdapter:
+    """Create adapter with no CLI path resolution."""
+    with patch.object(ClaudeCodeAdapter, "_resolve_cli_path", return_value=None):
+        return ClaudeCodeAdapter()
+
+
+@pytest.fixture
+def config() -> CompletionConfig:
+    return CompletionConfig(model="claude-sonnet-4-6")
+
+
+@pytest.fixture
+def messages() -> list[Message]:
+    return [Message(role=MessageRole.USER, content="Hello")]
+
+
+class TestEmptyResponseRetryCap:
+    """Tests for P0-AC1: empty-response retry cap + terminal fault code."""
+
+    @pytest.mark.asyncio
+    async def test_empty_with_session_stops_after_cap(
+        self, adapter: ClaudeCodeAdapter, config: CompletionConfig, messages: list[Message]
+    ) -> None:
+        """Mock 5 consecutive empty-with-session responses, verify only 2 attempts made."""
+        from ouroboros.core.errors import ProviderError
+
+        call_count = 0
+
+        async def mock_execute(prompt, cfg):
+            nonlocal call_count
+            call_count += 1
+            return Result.err(
+                ProviderError(
+                    message="Empty response from CLI - session started but no content produced",
+                    details={"session_id": "sess_abc", "content_length": 0},
+                )
+            )
+
+        with patch.object(adapter, "_execute_single_request", side_effect=mock_execute):
+            with patch("ouroboros.providers.claude_code_adapter.query", create=True):
+                with patch("ouroboros.providers.claude_code_adapter.ClaudeAgentOptions", create=True):
+                    result = await adapter.complete(messages, config)
+
+        assert result.is_err
+        assert call_count == _MAX_EMPTY_RESPONSE_WITH_SESSION  # 2, not 5
+        assert result.error.details["fault_code"] == "CLAUDE_EMPTY_RESPONSE"
+        assert result.error.details["session_id"] == "sess_abc"
+        assert result.error.details["attempt_count"] == _MAX_EMPTY_RESPONSE_WITH_SESSION
+
+    @pytest.mark.asyncio
+    async def test_empty_without_session_remains_retryable(
+        self, adapter: ClaudeCodeAdapter, config: CompletionConfig, messages: list[Message]
+    ) -> None:
+        """Mock empty-without-session then success, verify retry works."""
+        from ouroboros.core.errors import ProviderError
+        from ouroboros.providers.base import CompletionResponse, UsageInfo
+
+        call_count = 0
+
+        async def mock_execute(prompt, cfg):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return Result.err(
+                    ProviderError(
+                        message="Empty response from CLI - may need retry (timeout/startup)",
+                        details={"session_id": None, "content_length": 0},
+                    )
+                )
+            return Result.ok(
+                CompletionResponse(
+                    content="Hello!",
+                    model="claude-sonnet-4-6",
+                    usage=UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+                    finish_reason="stop",
+                    raw_response={},
+                )
+            )
+
+        with patch.object(adapter, "_execute_single_request", side_effect=mock_execute):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                result = await adapter.complete(messages, config)
+
+        assert result.is_ok
+        assert call_count == 2
+        assert result.value.content == "Hello!"
+
+    @pytest.mark.asyncio
+    async def test_empty_with_session_fault_code_in_payload(
+        self, adapter: ClaudeCodeAdapter, config: CompletionConfig, messages: list[Message]
+    ) -> None:
+        """Verify fault payload includes fault_code, session_id, attempt_count."""
+        from ouroboros.core.errors import ProviderError
+
+        async def mock_execute(prompt, cfg):
+            return Result.err(
+                ProviderError(
+                    message="Empty response from CLI - session started but no content produced",
+                    details={"session_id": "sess_xyz", "content_length": 0},
+                )
+            )
+
+        with patch.object(adapter, "_execute_single_request", side_effect=mock_execute):
+            result = await adapter.complete(messages, config)
+
+        assert result.is_err
+        details = result.error.details
+        assert details["fault_code"] == "CLAUDE_EMPTY_RESPONSE"
+        assert details["session_id"] == "sess_xyz"
+        assert details["attempt_count"] == 2
+        assert "prompt_preview" in details
+
+    @pytest.mark.asyncio
+    async def test_non_empty_error_resets_counter(
+        self, adapter: ClaudeCodeAdapter, config: CompletionConfig, messages: list[Message]
+    ) -> None:
+        """A non-empty error between empty responses resets the consecutive counter."""
+        from ouroboros.core.errors import ProviderError
+        from ouroboros.providers.base import CompletionResponse, UsageInfo
+
+        call_count = 0
+
+        async def mock_execute(prompt, cfg):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Empty with session
+                return Result.err(
+                    ProviderError(
+                        message="Empty response from CLI - session started but no content produced",
+                        details={"session_id": "sess_1", "content_length": 0},
+                    )
+                )
+            if call_count == 2:
+                # Different retryable error (resets counter)
+                return Result.err(
+                    ProviderError(
+                        message="rate limit exceeded",
+                        details={},
+                    )
+                )
+            if call_count == 3:
+                # Empty with session again (counter should be at 1, not 2)
+                return Result.err(
+                    ProviderError(
+                        message="Empty response from CLI - session started but no content produced",
+                        details={"session_id": "sess_1", "content_length": 0},
+                    )
+                )
+            # Success on 4th
+            return Result.ok(
+                CompletionResponse(
+                    content="Done",
+                    model="claude-sonnet-4-6",
+                    usage=UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+                    finish_reason="stop",
+                    raw_response={},
+                )
+            )
+
+        with patch.object(adapter, "_execute_single_request", side_effect=mock_execute):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                result = await adapter.complete(messages, config)
+
+        assert result.is_ok
+        assert call_count == 4


### PR DESCRIPTION
## Summary
- **P0-AC0**: Instrument `reconstruct_session()` with `event_count_replayed`, `duration_ms`, and `path: replay` structured log fields for baseline cost measurement
- **P0-AC1**: Cap empty-response retries at 2 consecutive when `session_id` is present; emit terminal `CLAUDE_EMPTY_RESPONSE` fault code. Startup-delay (no session_id) retries unchanged
- **P0-AC2**: Remove duplicate `session.started` emission from `runner.py`; add idempotency guard in `SessionRepository.create_session()`

Closes #1, closes #2.

## Test plan
- [x] `TestSessionReplayMetrics` — verify replay metrics in structured log
- [x] `TestSessionIdempotencyGuard` — verify single event per session_id, auto-ID bypass
- [x] `TestEmptyResponseRetryCap` — verify 2-attempt cap with session_id, retryable without, fault payload, counter reset
- [x] Full unit suite: 2240 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)